### PR TITLE
Fix 'parskip' warning from KOMA scrlttr2.

### DIFF
--- a/scrlttr2.latex
+++ b/scrlttr2.latex
@@ -139,15 +139,6 @@ $if(strikeout)$
 % avoid problems with \sout in headers with hyperref:
 \pdfstringdefDisableCommands{\renewcommand{\sout}{}}
 $endif$
-$if(indent)$
-$else$
-\IfFileExists{parskip.sty}{%
-\usepackage{parskip}
-}{% else
-\setlength{\parindent}{0pt}
-\setlength{\parskip}{6pt plus 2pt minus 1pt}
-}
-$endif$
 \setlength{\emergencystretch}{3em}  % prevent overfull lines
 \providecommand{\tightlist}{%
   \setlength{\itemsep}{0pt}\setlength{\parskip}{0pt}}
@@ -215,6 +206,7 @@ $endif$
 \KOMAoptions{fromphone=false}
 \KOMAoptions{fromurl=false}
 \KOMAoptions{fromalign=right}
+\KOMAoptions{parskip=half}
 
 $for(letteroption)$
 \LoadLetterOption{$letteroption$}


### PR DESCRIPTION
Manually running the example letter through `pandoc` and `pdflatex`
```
pandoc example-letter.md -o example-letter.tex --template=scrlttr2.latex
pdflatex example-letter.tex
```
produces (at least) the following warning from KOMA `scrlttr2`:
```
Class scrlttr2 Warning: Usage of package `parskip' together
(scrlttr2)              with a KOMA-Script class is not recommended.
(scrlttr2)              I'd suggest to use option
(scrlttr2)              `parskip' with one of it's several values.
(scrlttr2)              Nevertheless, using requested
(scrlttr2)              package `parskip' on input line 41.
```

This PR removes the non-KOMA use of `parskip` and uses the KOMA class option.