### PR TITLE
Fix LaTeX2e warning.

### DIFF
--- a/scrlttr2.latex
+++ b/scrlttr2.latex
@@ -10,7 +10,6 @@ $if(linestretch)$
 $endif$
 \usepackage{amssymb,amsmath}
 \usepackage{ifxetex,ifluatex}
-\usepackage{fixltx2e} % provides \textsubscript
 \ifnum 0\ifxetex 1\fi\ifluatex 1\fi=0 % if pdftex
   \usepackage[$if(fontenc)$$fontenc$$else$T1$endif$]{fontenc}
   \usepackage[utf8]{inputenc}


### PR DESCRIPTION
Manually running the example letter through `pandoc` and `pdflatex`
```
pandoc example-letter.md -o example-letter.tex --template=scrlttr2.latex
pdflatex example-letter.tex
```
produces (at least) the following warning from the LaTeX2e kernel:
```
Package fixltx2e Warning: fixltx2e is not required with releases after 2015
(fixltx2e)                All fixes are now in the LaTeX kernel.
(fixltx2e)                See the latexrelease package for details.
```

This PR simply removes the outdated LaTeX package request.